### PR TITLE
switch to UploadFileV2 API

### DIFF
--- a/reactor/anomaly_test.go
+++ b/reactor/anomaly_test.go
@@ -163,8 +163,11 @@ func TestGraphGenerator(t *testing.T) {
 		goldie.WithNameSuffix(".golden.png"),
 	)
 	for i, graph := range graphs {
-		bs, err := io.ReadAll(graph)
+		bs, err := io.ReadAll(graph.r)
 		require.NoError(t, err)
 		g.Assert(t, fmt.Sprintf("graph%d", i), bs)
+		if graph.size != int64(len(bs)) {
+			t.Errorf("unexpected size graph%d: want=%d got=%d", i, graph.size, len(bs))
+		}
 	}
 }


### PR DESCRIPTION
The legacy upload file API retires in March 2025.
https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay

UploadFileV2 requires FileSize, so I added a Graph struct to hold the size of the generated graph.