### PR TITLE
Handle Multiple SNS Notifications for the Same AnomalyID in AWS Cost Anomaly Detector

### DIFF
--- a/_examples/example_aws.tf
+++ b/_examples/example_aws.tf
@@ -72,6 +72,17 @@ data "aws_iam_policy_document" "reactor" {
     ]
     resources = ["*"]
   }
+  statement {
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:CreateTable",
+      "dynamodb:DescribeTable",
+      "dynamodb:DescribeTimeToLive",
+      "dynamodb:UpdateTimeToLive",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_sqs_queue" "reactor" {

--- a/_examples/function.json
+++ b/_examples/function.json
@@ -6,6 +6,7 @@
           "SQS_QUEUE_NAME": "aws-cost-anomaly-slack-reactor",
           "LOG_LEVEL": "debug",
           "SSMWRAP_PATHS": "/cost-anomaly-slack-reactor/",
+          "DYNAMODB_TABLE_NAME": "aws-cost-anomaly-slack-reactor",
           "TZ": "Asia/Tokyo"
       }
   },

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/aws/aws-lambda-go v1.47.0
 	github.com/aws/aws-sdk-go-v2 v1.27.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.15
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.19
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.19
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.3
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.5
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.27.6
@@ -38,6 +40,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.19.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.27.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.15
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.3
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.5
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.27.6
 	github.com/aws/aws-sdk-go-v2/service/sns v1.29.7
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.9
@@ -39,6 +40,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.19.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.6 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.53.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,10 @@ github.com/aws/aws-sdk-go-v2/config v1.27.15 h1:uNnGLZ+DutuNEkuPh6fwqK7LpEiPmzb7
 github.com/aws/aws-sdk-go-v2/config v1.27.15/go.mod h1:7j7Kxx9/7kTmL7z4LlhwQe63MYEE5vkVV6nWg4ZAI8M=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.15 h1:YDexlvDRCA8ems2T5IP1xkMtOZ1uLJOCJdTr0igs5zo=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.15/go.mod h1:vxHggqW6hFNaeNC0WyXS3VdyjcV0a4KMUY4dKJ96buU=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.19 h1:Y9GflNZ9Ty+qjyY7Oral0gcaeI5NiPNHX23vXCiXfe8=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.13.19/go.mod h1:RACJwWn6am6SvBqlCM9/DKHaR+79Q6/yMx3QCjuq8nw=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.19 h1:Hjjh0YZ/ZIye2lzc8BcpAao9kF5TgN+Ahq0+bFHgFYM=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression v1.7.19/go.mod h1:bVXiHrPXAHhmMNbIqmmEpogbB7kKLcqbIBvB/baupUA=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.3 h1:dQLK4TjtnlRGb0czOht2CevZ5l6RSyRWAnKeGd7VAFE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.3/go.mod h1:TL79f2P6+8Q7dTsILpiVST+AL9lkF6PPGI167Ny0Cjw=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.13 h1:F+PUZee9mlfpEJVZdgyewRumKekS9O3fftj8fEMt0rQ=
@@ -40,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.3 h1:PA0C+1L55J1T/+lbOqZ
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.3/go.mod h1:tixcI/0N745XN/7tA8acF1Tryt9m3XAQHXl4e+Rb7n4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.5 h1:HLbOhDOP/191cJLS829oCL8sn9tXF6qhAjh1emp8TEE=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.5/go.mod h1:uNhUf9Z3MT6Ex+u0ADa8r3MKK5zjuActEfXQPo4YqEI=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.20.8 h1:PapW7iWHqua6Gk+qRjgXpM3fNqUxY3N+1WURHPcmKhc=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.20.8/go.mod h1:IL6qnQxrc/qIjwzeg7USP3P7ySEehOPpXJslRbXNYJ4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 h1:Ji0DY1xUsUr3I8cHps0G+XM3WWU16lP6yG8qu1GAZAs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2/go.mod h1:5CsjAbs3NlGQyZNFACh+zztPDI7fU6eW9QsxjfnuBKg=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.6 h1:NkHCgg0Ck86c5PTOzBZ0JRccI51suJDg5lgFtxBu1ek=

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,14 @@ github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.19.3 h1:17zrIOFc
 github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.19.3/go.mod h1:3x97ajqHUnxTd7R+XHq+bHHLkxn+5vPbiem+8zTGjuA=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.3 h1:PA0C+1L55J1T/+lbOqZUdVLMMCHK/zuR4mKJTyB4dho=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.3/go.mod h1:tixcI/0N745XN/7tA8acF1Tryt9m3XAQHXl4e+Rb7n4=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.5 h1:HLbOhDOP/191cJLS829oCL8sn9tXF6qhAjh1emp8TEE=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.32.5/go.mod h1:uNhUf9Z3MT6Ex+u0ADa8r3MKK5zjuActEfXQPo4YqEI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 h1:Ji0DY1xUsUr3I8cHps0G+XM3WWU16lP6yG8qu1GAZAs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2/go.mod h1:5CsjAbs3NlGQyZNFACh+zztPDI7fU6eW9QsxjfnuBKg=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.6 h1:NkHCgg0Ck86c5PTOzBZ0JRccI51suJDg5lgFtxBu1ek=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.3.6/go.mod h1:mjTpxjC8v4SeINTngrnKFgm2QUi+Jm+etTbCxh8W4uU=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8 h1:yEeIld7Fh/2iM4pYeQw8a3kH6OYcyIn6lwKlUFiVk7Y=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.9.8/go.mod h1:lZJMX2Z5/rQ6OlSbBnW1WWScK6ngLt43xtqM8voMm2w=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.9 h1:Wx0rlZoEJR7JwlSZcHnEa7CNjrSIyVxMFWGAaXy4fJY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.9/go.mod h1:aVMHdE0aHO3v+f/iw01fmXV/5DbfQ3Bi9nN7nd9bE9Y=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.4 h1:uDj2K47EM1reAYU9jVlQ1M5YENI1u6a/TxJpf6AeOLA=

--- a/main.go
+++ b/main.go
@@ -96,9 +96,12 @@ func main() {
 	if sqsQueueName == "" {
 		ridge.RunWithContext(ctx, address, prefix, h)
 	} else {
-		canyon.RunWithContext(ctx, sqsQueueName, h,
+		err := canyon.RunWithContext(ctx, sqsQueueName, h,
 			canyon.WithServerAddress(address, prefix),
 			canyon.WithCanyonEnv("CANYON_"),
 		)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 }

--- a/reactor/handler.go
+++ b/reactor/handler.go
@@ -20,6 +20,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -43,6 +45,7 @@ type Handler struct {
 	channel           string
 	botUserID         string
 	botID             string
+	slackTeamID       string
 	signalSecret      string
 	awsAccountID      string
 	noErrorReport     bool
@@ -132,7 +135,7 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 		params.logger.Debug("failed to get aws account id", "error", err)
 	}
 
-	var botID, botUserID string
+	var botID, botUserID, teamID string
 	client := slack.New(params.slackBotToken)
 	if params.slackBotToken != "" {
 		me, err := client.AuthTest()
@@ -149,6 +152,7 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 		)
 		botID = me.BotID
 		botUserID = me.UserID
+		teamID = me.TeamID
 	} else {
 		params.logger.Warn("slack bot token is not set, running anonymous mode")
 	}
@@ -163,6 +167,7 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 		botID:             botID,
 		channel:           params.slackChannel,
 		botUserID:         botUserID,
+		slackTeamID:       teamID,
 		signalSecret:      params.slackSignalSecret,
 		awsAccountID:      awsAccountID,
 		noErrorReport:     params.noErrorReport,
@@ -239,10 +244,6 @@ func (h *Handler) PrepareDynamoDBTable(ctx context.Context) error {
 						AttributeName: aws.String("SlackTeamID"),
 						AttributeType: ddbtypes.ScalarAttributeTypeS,
 					},
-					{
-						AttributeName: aws.String("TTL"),
-						AttributeType: ddbtypes.ScalarAttributeTypeN,
-					},
 				},
 				BillingMode: ddbtypes.BillingModePayPerRequest,
 			})
@@ -304,6 +305,62 @@ func (h *Handler) PrepareDynamoDBTable(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+type AnomalySlackMessage struct {
+	AnomalyID             string
+	SlackTeamID           string
+	SlackMessageTimestamp string
+	TotalImpact           float64
+	TTL                   time.Time
+}
+
+func (h *Handler) SaveAnomalySlackMessage(ctx context.Context, m *AnomalySlackMessage) error {
+	m.SlackTeamID = h.slackTeamID
+	m.TTL = time.Now().AddDate(0, 1, 0)
+	h.logger.DebugContext(ctx, "save anomaly slack message", "anomaly_id", m.AnomalyID, "slack_team_id", m.SlackTeamID)
+	item, err := attributevalue.MarshalMap(m)
+	if err != nil {
+		return fmt.Errorf("failed to marshal item: %w", err)
+	}
+	expr, err := expression.NewBuilder().WithCondition(
+		expression.AttributeNotExists(expression.Name("AnomalyID")).And(expression.AttributeNotExists(expression.Name("SlackTeamID"))),
+	).Build()
+	if err != nil {
+		return fmt.Errorf("failed to build expression: %w", err)
+	}
+	_, err = h.ddb.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(h.dynamodbTableName),
+		Item:                item,
+		ConditionExpression: expr.Condition(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to put item: %w", err)
+	}
+	return nil
+}
+
+func (h *Handler) GetAnomalySlackMessage(ctx context.Context, anomalyID string) (*AnomalySlackMessage, bool, error) {
+	h.logger.DebugContext(ctx, "get anomaly slack message", "anomaly_id", anomalyID, "slack_team_id", h.slackTeamID)
+	output, err := h.ddb.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(h.dynamodbTableName),
+		Key: map[string]ddbtypes.AttributeValue{
+			"AnomalyID":   &ddbtypes.AttributeValueMemberS{Value: anomalyID},
+			"SlackTeamID": &ddbtypes.AttributeValueMemberS{Value: h.slackTeamID},
+		},
+	})
+	if err != nil {
+		var notFound *ddbtypes.ResourceNotFoundException
+		if errors.As(err, &notFound) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to get item: %w", err)
+	}
+	var m AnomalySlackMessage
+	if err := attributevalue.UnmarshalMap(output.Item, &m); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal item: %w", err)
+	}
+	return &m, true, nil
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -660,10 +717,45 @@ func (h *Handler) postAnomalyDetectedMessage(ctx context.Context, a Anomaly) err
 	if err != nil {
 		return fmt.Errorf("failed to generate graphs: %w", err)
 	}
-
-	_, ts, err := h.client.PostMessageContext(ctx, h.channel, opts...)
-	if err != nil {
-		return fmt.Errorf("failed to post message: %w", err)
+	var posted bool
+	var ts string
+	if h.EnableDynamoDB() {
+		msg, ok, err := h.GetAnomalySlackMessage(ctx, a.AnomalyID)
+		if err != nil {
+			h.logger.WarnContext(ctx, "failed to get anomaly slack message", "error", err)
+		}
+		if ok {
+			posted = true
+			ts = msg.SlackMessageTimestamp
+			updateText := fmt.Sprintf("Update Total Impact `%f` to `%f`", msg.TotalImpact, a.Impact.TotalImpact)
+			_, _, err = h.client.PostMessageContext(
+				ctx, h.channel,
+				slack.MsgOptionTS(ts),
+				slack.MsgOptionText(updateText, false),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to post message: %w", err)
+			}
+			_, _, _, err = h.client.UpdateMessageContext(ctx, h.channel, ts, opts...)
+			if err != nil {
+				return fmt.Errorf("failed to update message: %w", err)
+			}
+		}
+	}
+	if !posted {
+		_, ts, err = h.client.PostMessageContext(ctx, h.channel, opts...)
+		if err != nil {
+			return fmt.Errorf("failed to post message: %w", err)
+		}
+		if h.EnableDynamoDB() {
+			if err := h.SaveAnomalySlackMessage(ctx, &AnomalySlackMessage{
+				AnomalyID:             a.AnomalyID,
+				SlackMessageTimestamp: ts,
+				TotalImpact:           a.Impact.TotalImpact,
+			}); err != nil {
+				h.logger.WarnContext(ctx, "failed to save anomaly slack message", "error", err, "anomaly_id", a.AnomalyID)
+			}
+		}
 	}
 	h.logger.Info("post anomaly detected message", "anomaly_id", a.AnomalyID, "thread_ts", ts)
 	for i, g := range graphs {

--- a/reactor/handler.go
+++ b/reactor/handler.go
@@ -32,18 +32,19 @@ import (
 )
 
 type Handler struct {
-	ce            *costexplorer.Client
-	org           *organizations.Client
-	client        *slack.Client
-	logger        *slog.Logger
-	router        *mux.Router
-	channel       string
-	botUserID     string
-	botID         string
-	signalSecret  string
-	awsAccountID  string
-	noErrorReport bool
-	tpl           *template.Template
+	ce                *costexplorer.Client
+	org               *organizations.Client
+	client            *slack.Client
+	logger            *slog.Logger
+	router            *mux.Router
+	channel           string
+	botUserID         string
+	botID             string
+	signalSecret      string
+	awsAccountID      string
+	noErrorReport     bool
+	tpl               *template.Template
+	dynamodbTableName string
 }
 
 var _ http.Handler = (*Handler)(nil)
@@ -150,18 +151,19 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 	}
 	router := mux.NewRouter()
 	h := &Handler{
-		ce:            costexplorer.NewFromConfig(*params.awsCfg),
-		org:           organizations.NewFromConfig(*params.awsCfg),
-		logger:        params.logger.With("component", "handler"),
-		router:        router,
-		client:        client,
-		botID:         botID,
-		channel:       params.slackChannel,
-		botUserID:     botUserID,
-		signalSecret:  params.slackSignalSecret,
-		awsAccountID:  awsAccountID,
-		noErrorReport: params.noErrorReport,
-		tpl:           tpl,
+		ce:                costexplorer.NewFromConfig(*params.awsCfg),
+		org:               organizations.NewFromConfig(*params.awsCfg),
+		logger:            params.logger.With("component", "handler"),
+		router:            router,
+		client:            client,
+		botID:             botID,
+		channel:           params.slackChannel,
+		botUserID:         botUserID,
+		signalSecret:      params.slackSignalSecret,
+		awsAccountID:      awsAccountID,
+		noErrorReport:     params.noErrorReport,
+		dynamodbTableName: params.dynamodbTableName,
+		tpl:               tpl,
 	}
 	var dummy templateData
 	if _, err := h.newDetectAnomalyMessageOptions(dummy); err != nil {

--- a/reactor/options.go
+++ b/reactor/options.go
@@ -13,6 +13,7 @@ type optionParams struct {
 	slackChannel      string
 	slackSignalSecret string
 	templateStr       string
+	dynamodbTableName string
 	noErrorReport     bool
 }
 
@@ -57,5 +58,11 @@ func WithTemplate(template string) Option {
 func WithNoErrorReport() Option {
 	return func(args *optionParams) {
 		args.noErrorReport = true
+	}
+}
+
+func WithDynamoDBTableName(tableName string) Option {
+	return func(args *optionParams) {
+		args.dynamodbTableName = tableName
 	}
 }


### PR DESCRIPTION
When AWS cost anomaly detection is enabled, it is possible to receive multiple SNS notifications with the same AnomalyID. Currently, this results in multiple Slack messages being posted, which can be inconvenient. To streamline this, we need to consolidate these notifications into a single message.

To achieve this, the Slack message timestamp from the first notification needs to be stored somewhere. By introducing a DynamoDB table, specified by the environment variable DYNAMODB_TABLE_NAME, we can save this information. When an SNS notification arrives, the system will check if the AnomalyID has already been posted.

If it has been posted, the existing message will be updated; if not, a new message will be created.