### PR TITLE
chore(lint): clean up golangci-lint warnings (58 -> 0 on tracked sources)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
-version: 2
+version: "2"
 
 linters:
-  disable-all: true
+  default: none
   enable:
     - govet
     - revive
@@ -18,13 +18,15 @@ linters:
       check-blank: true
       exclude-functions:
         - (io.Closer).Close
+        - (net/http.ResponseWriter).Write
+
+  exclusions:
+    paths:
+      - ".*\\.gen\\.go$"
 
 run:
-  tests: true
-  timeout: 5m
-  skip-files:
-    - ".*\\.gen\\.go$"
-    - ".*_test\\.go$"
+  tests: false
+  timeout: 15m
 
 formatters:
   enable:
@@ -34,7 +36,8 @@ formatters:
     gofmt:
       simplify: true
     goimports:
-      local-prefixes: github.com/my_org
+      local-prefixes:
+        - github.com/mashiike
   exclusions:
     paths:
       - ".*\\.gen\\.go$"

--- a/internal/costexplorerx/get_anomalies_paginator.go
+++ b/internal/costexplorerx/get_anomalies_paginator.go
@@ -1,3 +1,5 @@
+// Package costexplorerx provides paginators for AWS Cost Explorer API calls
+// that are not covered by the official aws-sdk-go-v2 paginator helpers.
 package costexplorerx
 
 import (
@@ -6,12 +8,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 )
 
+// GetAnomaliesAPIClient is the subset of the Cost Explorer client used by
+// GetAnomaliesPaginator.
 type GetAnomaliesAPIClient interface {
 	GetAnomalies(context.Context, *costexplorer.GetAnomaliesInput, ...func(*costexplorer.Options)) (*costexplorer.GetAnomaliesOutput, error)
 }
 
 var _ GetAnomaliesAPIClient = (*costexplorer.Client)(nil)
 
+// GetAnomaliesPaginator paginates over Cost Explorer GetAnomalies results.
 type GetAnomaliesPaginator struct {
 	client    GetAnomaliesAPIClient
 	params    *costexplorer.GetAnomaliesInput
@@ -19,6 +24,7 @@ type GetAnomaliesPaginator struct {
 	firstPage bool
 }
 
+// NewGetAnomaliesPaginator returns a new paginator for GetAnomalies.
 func NewGetAnomaliesPaginator(client GetAnomaliesAPIClient, params *costexplorer.GetAnomaliesInput) *GetAnomaliesPaginator {
 	return &GetAnomaliesPaginator{
 		client:    client,
@@ -27,10 +33,12 @@ func NewGetAnomaliesPaginator(client GetAnomaliesAPIClient, params *costexplorer
 	}
 }
 
+// HasMorePages reports whether there are more pages to fetch.
 func (p *GetAnomaliesPaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }
 
+// NextPage fetches the next page of GetAnomalies results.
 func (p *GetAnomaliesPaginator) NextPage(ctx context.Context, optFns ...func(*costexplorer.Options)) (*costexplorer.GetAnomaliesOutput, error) {
 	if !p.HasMorePages() {
 		return nil, nil

--- a/internal/costexplorerx/get_cost_and_usage_paginator.go
+++ b/internal/costexplorerx/get_cost_and_usage_paginator.go
@@ -6,12 +6,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 )
 
+// GetCostAndUsageAPIClient is the subset of the Cost Explorer client used by
+// GetCostAndUsagePaginator.
 type GetCostAndUsageAPIClient interface {
 	GetCostAndUsage(context.Context, *costexplorer.GetCostAndUsageInput, ...func(*costexplorer.Options)) (*costexplorer.GetCostAndUsageOutput, error)
 }
 
 var _ GetCostAndUsageAPIClient = (*costexplorer.Client)(nil)
 
+// GetCostAndUsagePaginator paginates over Cost Explorer GetCostAndUsage results.
 type GetCostAndUsagePaginator struct {
 	client    GetCostAndUsageAPIClient
 	params    *costexplorer.GetCostAndUsageInput
@@ -19,6 +22,7 @@ type GetCostAndUsagePaginator struct {
 	firstPage bool
 }
 
+// NewGetCostAndUsagePaginator returns a new paginator for GetCostAndUsage.
 func NewGetCostAndUsagePaginator(client GetCostAndUsageAPIClient, params *costexplorer.GetCostAndUsageInput) *GetCostAndUsagePaginator {
 	return &GetCostAndUsagePaginator{
 		client:    client,
@@ -27,10 +31,12 @@ func NewGetCostAndUsagePaginator(client GetCostAndUsageAPIClient, params *costex
 	}
 }
 
+// HasMorePages reports whether there are more pages to fetch.
 func (p *GetCostAndUsagePaginator) HasMorePages() bool {
 	return p.firstPage || (p.nextToken != nil && len(*p.nextToken) != 0)
 }
 
+// NextPage fetches the next page of GetCostAndUsage results.
 func (p *GetCostAndUsagePaginator) NextPage(ctx context.Context, optFns ...func(*costexplorer.Options)) (*costexplorer.GetCostAndUsageOutput, error) {
 	if !p.HasMorePages() {
 		return nil, nil

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+// Command aws-cost-anomaly-slack-reactor is the entry point that runs the
+// reactor handler either as a local HTTP server or as an AWS Lambda function.
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fujiwara/ridge"
 	"github.com/handlename/ssmwrap/v2"
 	"github.com/ken39arg/go-flagx"
+
 	"github.com/mashiike/aws-cost-anomaly-slack-reactor/reactor"
 	"github.com/mashiike/canyon"
 	"github.com/mashiike/slogutils"

--- a/reactor/anomaly.go
+++ b/reactor/anomaly.go
@@ -1,3 +1,6 @@
+// Package reactor implements the HTTP handler that reacts to AWS Cost Anomaly
+// SNS notifications by posting anomaly summaries and root-cause cost graphs to
+// Slack, and forwards Slack action responses back as Cost Anomaly feedback.
 package reactor
 
 import (

--- a/reactor/anomaly.go
+++ b/reactor/anomaly.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mashiike/aws-cost-anomaly-slack-reactor/internal/costexplorerx"
 )
 
+// Anomaly is the AWS Cost Anomaly payload delivered via SNS.
 type Anomaly struct {
 	AccountID          string        `json:"accountId"`
 	AnomalyDetailsLink string        `json:"anomalyDetailsLink"`
@@ -35,11 +36,13 @@ type Anomaly struct {
 	SubscriptionName   string        `json:"subscriptionName"`
 }
 
+// AnomalyScore is the score assigned to an Anomaly by Cost Anomaly Detection.
 type AnomalyScore struct {
 	CurrentScore float64 `json:"currentScore"`
 	MaxScore     float64 `json:"maxScore"`
 }
 
+// AnomalyImpact summarises the cost impact of an Anomaly.
 type AnomalyImpact struct {
 	MaxImpact             float64 `json:"maxImpact"`
 	TotalActualSpend      float64 `json:"totalActualSpend"`
@@ -48,6 +51,8 @@ type AnomalyImpact struct {
 	TotalImpactPercentage float64 `json:"totalImpactPercentage"`
 }
 
+// RootCause identifies a service / account / region dimension that contributed
+// to the Anomaly's cost.
 type RootCause struct {
 	LinkedAccount     string `json:"linkedAccount"`
 	LinkedAccountName string `json:"linkedAccountName"`
@@ -56,15 +61,20 @@ type RootCause struct {
 	UsageType         string `json:"usageType"`
 }
 
+// Graph is a rendered PNG image (typically of an Anomaly's cost trend) with
+// its byte size.
 type Graph struct {
 	r    io.Reader
 	size int64
 }
 
+// DescribeAccountAPIClient is the subset of the AWS Organizations client used
+// to look up an account name by ID.
 type DescribeAccountAPIClient interface {
 	DescribeAccount(ctx context.Context, input *organizations.DescribeAccountInput, optFns ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error)
 }
 
+// GraphGenerator renders root-cause cost graphs for a given Anomaly.
 type GraphGenerator struct {
 	client                     costexplorerx.GetCostAndUsageAPIClient
 	org                        DescribeAccountAPIClient
@@ -74,6 +84,8 @@ type GraphGenerator struct {
 	cacheDescribeAccountExpire map[string]time.Time
 }
 
+// NewGraphGenerator returns a GraphGenerator backed by the given Cost Explorer
+// and Organizations clients.
 func NewGraphGenerator(client costexplorerx.GetCostAndUsageAPIClient, org DescribeAccountAPIClient) *GraphGenerator {
 	return &GraphGenerator{
 		client:                     client,
@@ -100,6 +112,7 @@ func (g *GraphGenerator) describeAccount(ctx context.Context, accountID string) 
 	return out, nil
 }
 
+// Generate renders one Graph per RootCause of the given Anomaly.
 func (g *GraphGenerator) Generate(ctx context.Context, anomaly Anomaly) ([]*Graph, error) {
 	graphs := make([]*Graph, 0, len(anomaly.RootCauses))
 	for _, c := range anomaly.RootCauses {
@@ -148,6 +161,9 @@ func (g *GraphGenerator) generate(ctx context.Context, startAt, endAt time.Time,
 	return w, nil
 }
 
+// IsSavingsPlanApplied reports whether Savings Plans typically apply to the
+// RootCause's service, in which case the graph is also rendered without the
+// SavingsPlan negation to show on-demand cost.
 func (g *GraphGenerator) IsSavingsPlanApplied(c RootCause) bool {
 	if strings.Contains(c.Service, "Amazon Elastic Compute Cloud") {
 		return true

--- a/reactor/anomaly.go
+++ b/reactor/anomaly.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
+
 	"github.com/mashiike/aws-cost-anomaly-slack-reactor/internal/costexplorerx"
 )
 

--- a/reactor/graph.go
+++ b/reactor/graph.go
@@ -208,17 +208,17 @@ func (t *graphTicker) Len() int {
 
 const maxLabels = 8
 
-func (t *graphTicker) Ticks(min, max float64) []plot.Tick {
+func (t *graphTicker) Ticks(lo, hi float64) []plot.Tick {
 	dates := t.Dates()
 	interval := int(math.Ceil(float64(len(dates)) / float64(maxLabels)))
 	var ticks []plot.Tick
 	for i, date := range dates {
-		if float64(i) >= min && float64(i) <= max {
+		if float64(i) >= lo && float64(i) <= hi {
 			tick := plot.Tick{
 				Value: float64(i),
 				Label: date.Format("2006-01-02"),
 			}
-			if int(float64(i)-min)%interval != 0 {
+			if int(float64(i)-lo)%interval != 0 {
 				tick.Label = ""
 			}
 			ticks = append(ticks, tick)

--- a/reactor/graph.go
+++ b/reactor/graph.go
@@ -13,6 +13,8 @@ import (
 	"gonum.org/v1/plot/vg"
 )
 
+// CostGraph accumulates dated cost data points per legend and renders them as
+// a stacked or grouped bar chart PNG.
 type CostGraph struct {
 	mu          sync.Mutex
 	ticker      graphTicker
@@ -20,6 +22,7 @@ type CostGraph struct {
 	EnableStack bool
 }
 
+// NewCostGraph returns an empty CostGraph with stacking enabled.
 func NewCostGraph() *CostGraph {
 	return &CostGraph{
 		dataPoints: make(map[string]map[time.Time]float64),
@@ -30,6 +33,7 @@ func NewCostGraph() *CostGraph {
 	}
 }
 
+// AddDataPoint records a cost value at time t under the given legend.
 func (g *CostGraph) AddDataPoint(t time.Time, cost float64, legend string) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -55,6 +59,8 @@ var graphColors = []color.RGBA{
 	{R: 140, G: 81, B: 10, A: 255},
 }
 
+// WriteTo renders the accumulated data points to a PNG and returns an
+// io.WriterTo for the encoded image.
 func (g *CostGraph) WriteTo(title string, yLabel string) (io.WriterTo, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/reactor/handler.go
+++ b/reactor/handler.go
@@ -29,9 +29,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/gorilla/mux"
-	"github.com/mashiike/canyon"
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
+
+	"github.com/mashiike/canyon"
 )
 
 // Handler is the http.Handler that receives AWS Cost Anomaly SNS notifications
@@ -628,7 +629,9 @@ func (h *Handler) processInteractiveMessage(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		h.logger.Warn("failed to parse action value", "error", err)
 		if isWorker {
-			postToThread(ctx, slack.MsgOptionText(fmt.Sprintf("[error] failed to parse action value: %s", err), false))
+			if postErr := postToThread(ctx, slack.MsgOptionText(fmt.Sprintf("[error] failed to parse action value: %s", err), false)); postErr != nil {
+				h.logger.WarnContext(ctx, "failed to post to thread", "error", postErr)
+			}
 		}
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -638,17 +641,21 @@ func (h *Handler) processInteractiveMessage(w http.ResponseWriter, r *http.Reque
 	if err := h.ProvideFeedback(ctx, anomalyID, action.ActionID); err != nil {
 		h.logger.Error("failed to provide feedback", "error", err)
 		if isWorker {
-			postToThread(ctx,
+			if postErr := postToThread(ctx,
 				slack.MsgOptionText(fmt.Sprintf("[error] failed to provide feedback: %s", err), false),
-			)
+			); postErr != nil {
+				h.logger.WarnContext(ctx, "failed to post to thread", "error", postErr)
+			}
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	postToThread(ctx,
+	if postErr := postToThread(ctx,
 		slack.MsgOptionText(fmt.Sprintf("Feedback of `%s` was provided for AnomalyID `%s` by user `%s` .", action.Text.Text, anomalyID, actionUser.Name), false),
 		slack.MsgOptionBroadcast(),
-	)
+	); postErr != nil {
+		h.logger.WarnContext(ctx, "failed to post to thread", "error", postErr)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/reactor/handler.go
+++ b/reactor/handler.go
@@ -34,6 +34,8 @@ import (
 	"github.com/slack-go/slack/slackevents"
 )
 
+// Handler is the http.Handler that receives AWS Cost Anomaly SNS notifications
+// and Slack events, posts anomaly messages to Slack, and records user feedback.
 type Handler struct {
 	ce                *costexplorer.Client
 	org               *organizations.Client
@@ -57,6 +59,8 @@ var _ http.Handler = (*Handler)(nil)
 //go:embed default_message.json.tpl
 var defaultTemplate string
 
+// New constructs a Handler from the given options, validating required
+// settings and initialising the AWS and Slack clients.
 func New(ctx context.Context, opts ...Option) (*Handler, error) {
 	token, ok := os.LookupEnv("SLACK_TOKEN")
 	if !ok {
@@ -110,7 +114,7 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 			if err != nil {
 				return "", err
 			}
-			return string([]byte(bs)[1 : len(bs)-1]), nil
+			return string(bs[1 : len(bs)-1]), nil
 		},
 		"to_date_str": func(t time.Time) string {
 			return t.Format("2006-01-02")
@@ -208,10 +212,14 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 	return h, nil
 }
 
+// EnableDynamoDB reports whether the Handler has a DynamoDB table configured
+// for persisting Slack message state.
 func (h *Handler) EnableDynamoDB() bool {
 	return h.dynamodbTableName != ""
 }
 
+// PrepareDynamoDBTable creates the configured DynamoDB table if it does not
+// exist and enables TTL on the TTL attribute.
 func (h *Handler) PrepareDynamoDBTable(ctx context.Context) error {
 	h.logger.DebugContext(ctx, "prepare dynamodb table", "table_name", h.dynamodbTableName)
 	// check table exists
@@ -306,6 +314,8 @@ func (h *Handler) PrepareDynamoDBTable(ctx context.Context) error {
 	return nil
 }
 
+// AnomalySlackMessage is the DynamoDB record that links an AWS Cost Anomaly
+// to the Slack thread where it was posted.
 type AnomalySlackMessage struct {
 	AnomalyID             string
 	SlackTeamID           string
@@ -314,6 +324,8 @@ type AnomalySlackMessage struct {
 	TTL                   int64
 }
 
+// SaveAnomalySlackMessage stores the AnomalySlackMessage in DynamoDB, setting
+// SlackTeamID from the Handler and a 1-month TTL.
 func (h *Handler) SaveAnomalySlackMessage(ctx context.Context, m *AnomalySlackMessage) error {
 	m.SlackTeamID = h.slackTeamID
 	m.TTL = time.Now().AddDate(0, 1, 0).Unix()
@@ -332,6 +344,8 @@ func (h *Handler) SaveAnomalySlackMessage(ctx context.Context, m *AnomalySlackMe
 	return nil
 }
 
+// GetAnomalySlackMessage looks up a previously saved AnomalySlackMessage by
+// anomaly ID. The boolean return is false when no record is found.
 func (h *Handler) GetAnomalySlackMessage(ctx context.Context, anomalyID string) (*AnomalySlackMessage, bool, error) {
 	h.logger.DebugContext(ctx, "get anomaly slack message", "anomaly_id", anomalyID, "slack_team_id", h.slackTeamID)
 	output, err := h.ddb.GetItem(ctx, &dynamodb.GetItemInput{
@@ -799,6 +813,8 @@ func (h *Handler) postAnomalyDetectedMessage(ctx context.Context, a Anomaly) err
 	return nil
 }
 
+// ProvideFeedback forwards the Slack action ID as Cost Anomaly Detection
+// feedback (Yes / No / PlannedActivity) for the given anomaly.
 func (h *Handler) ProvideFeedback(ctx context.Context, annomalyID string, actionID string) error {
 	var feedbackType types.AnomalyFeedbackType
 	switch actionID {

--- a/reactor/handler.go
+++ b/reactor/handler.go
@@ -188,13 +188,13 @@ func New(ctx context.Context, opts ...Option) (*Handler, error) {
 	if _, err := h.newDetectAnomalyMessageOptions(dummy); err != nil {
 		return nil, fmt.Errorf("failed to create default message: %w", err)
 	}
-	router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
-	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	})
-	router.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	router.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 	router.HandleFunc("/amazon-sns", h.handleAmazonSNS).Methods(http.MethodPost)
@@ -381,7 +381,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // https://docs.aws.amazon.com/sns/latest/dg/json-formats.html
 type httpNotification struct {
 	Type             string    `json:"Type"`
-	MessageId        string    `json:"MessageId"`
+	MessageId        string    `json:"MessageId"` //nolint:revive // field name mirrors AWS SNS HTTP notification JSON
 	Token            string    `json:"Token,omitempty"`
 	TopicArn         string    `json:"TopicArn"`
 	Subject          string    `json:"Subject,omitempty"`

--- a/reactor/options.go
+++ b/reactor/options.go
@@ -17,50 +17,60 @@ type optionParams struct {
 	noErrorReport     bool
 }
 
+// Option configures a Handler created by New.
 type Option func(*optionParams)
 
+// WithAWSConfig sets the AWS SDK config used by the Handler.
 func WithAWSConfig(cfg *aws.Config) Option {
 	return func(args *optionParams) {
 		args.awsCfg = cfg
 	}
 }
 
+// WithSlackBotToken sets the Slack bot token used by the Handler.
 func WithSlackBotToken(token string) Option {
 	return func(args *optionParams) {
 		args.slackBotToken = token
 	}
 }
 
+// WithLogger sets the slog.Logger used by the Handler.
 func WithLogger(logger *slog.Logger) Option {
 	return func(args *optionParams) {
 		args.logger = logger
 	}
 }
 
+// WithSlackChannel sets the Slack channel the Handler posts messages to.
 func WithSlackChannel(channel string) Option {
 	return func(args *optionParams) {
 		args.slackChannel = channel
 	}
 }
 
+// WithSlackSignalSecret sets the Slack signing secret used to verify incoming
+// Slack events.
 func WithSlackSignalSecret(secret string) Option {
 	return func(args *optionParams) {
 		args.slackSignalSecret = secret
 	}
 }
 
+// WithTemplate sets the message template used by the Handler.
 func WithTemplate(template string) Option {
 	return func(args *optionParams) {
 		args.templateStr = template
 	}
 }
 
+// WithNoErrorReport disables posting handler errors back to Slack.
 func WithNoErrorReport() Option {
 	return func(args *optionParams) {
 		args.noErrorReport = true
 	}
 }
 
+// WithDynamoDBTableName enables DynamoDB-backed state and sets the table name.
 func WithDynamoDBTableName(tableName string) Option {
 	return func(args *optionParams) {
 		args.dynamodbTableName = tableName


### PR DESCRIPTION
## Summary

Follow-up to #169 / #170. Drives `golangci-lint run` warnings from **58** down to **0** on all tracked source files (the 3 remaining warnings live entirely under `my-local/`, which is globally gitignored sandbox).

## Commits

1. **`chore(lint): add GoDoc to exported symbols and drop unnecessary conversion`** (`4247659`)
   - 1-line GoDoc for exported types/functions/methods in `reactor/{handler,anomaly,graph,options}.go` and `internal/costexplorerx/`.
   - Package-level comments for `main` and `costexplorerx`.
   - Drop redundant `[]byte(bs)` conversion in the `json_escape` template func.
   - 58 -> 16 warnings.

2. **`chore(lint): align .golangci.yaml with v2 schema and handle postToThread errors`** (`928b00f`)
   - Bring `.golangci.yaml` to proper v2 schema: `version: "2"`, `linters.default: none`, drop deprecated `run.skip-files` (replaced by `run.tests:false` + `linters.exclusions.paths`), array form for `goimports.local-prefixes`.
   - Set `local-prefixes` to `github.com/mashiike` (was placeholder `github.com/my_org`) and reformat affected imports.
   - Bump `run.timeout` 5m -> 15m.
   - Exclude `(net/http.ResponseWriter).Write` from errcheck (idiomatic).
   - Receive `postToThread`'s `error` return at three call sites in the Slack interactive handler and log at warn level instead of dropping it.
   - 16 -> 9 warnings (+ 3 my-local).

3. **`chore(lint): resolve remaining revive warnings on tracked sources`** (`94f2bf7`)
   - `// Package reactor ...` doc comment in `reactor/anomaly.go`.
   - `_ *http.Request` for the 3 inline handlers that ignore the request.
   - Rename `graphTicker.Ticks(min, max)` -> `Ticks(lo, hi)` to avoid shadowing Go 1.21's built-in min/max.
   - `//nolint:revive` on `httpNotification.MessageId` (mirrors AWS SNS JSON schema).
   - 9 -> 3 warnings (all 3 in `my-local/`).

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test -race ./... -timeout 60s` all PASS
- [x] `golangci-lint config verify` clean
- [x] `golangci-lint run` 3 warnings remain, all under `my-local/` (untracked)
- [x] `golangci-lint run --new-from-rev=origin/main` 0 new warnings
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)