### PR TITLE
docs(skill): add setup-reactor onboarding guide

### DIFF
--- a/.claude/skills/setup-reactor/SKILL.md
+++ b/.claude/skills/setup-reactor/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: setup-reactor
+description: aws-cost-anomaly-slack-reactor を新規に導入するための対話ガイド。AWS Cost Anomaly Detection の通知を Slack に流したい、このリポジトリ (aws-cost-anomaly-slack-reactor) を導入したい、Cost Anomaly のメール通知を Slack に切り替えたい、SNS + Lambda + Slack の初期構築をしたい、といった要望で起動する。`/setup-reactor` で明示発火。
+---
+
+# setup-reactor: aws-cost-anomaly-slack-reactor 初期セットアップ支援
+
+このリポジトリ (`aws-cost-anomaly-slack-reactor`) を新規に導入する End User のための対話ガイド。**既存の AWS Cost Anomaly Detection Monitor のアラートを Slack に届ける状態**まで誘導する。
+
+このガイドは「何を作るか・どこで詰まりやすいか」の知見を伝える役割に専念する。実行戦略 (どこまで自動でやるか・どこで承認を取るか) は End User の Claude Code 環境側の責務であり、このガイドでは規定しない。
+
+## 重要な前提
+
+- **End User が能動的に決定するのは「Slack 通知先のチャンネル」のみ**。他の項目 (Region・命名・閾値・Monitor 設定など) は既存環境/既存運用に従う、または環境依存のため End User の選好を尊重する
+- **外部仕様 (Slack App manifest, AWS docs, Terraform provider, OSS の最新リリース) は時間で変わる**。各フェーズで「最新仕様は一次資料 (公式 docs / 最新リリース / README) で確認してください」と End User に促すこと
+- **Terraform を基本に提示する**。End User が CLI / Console を希望すれば翻訳して提供する
+- **OSS の README / `_examples/` と重複する手順はリンクで委ねる**。このガイドは判断・順序・落とし穴に集中する
+
+## 対話フロー (F1 → F6)
+
+順序が重要。**F5 の疎通確認が成功してから F6 の Monitor 接続に進む** — 逆順だと本番の Cost Anomaly 通知が Slack に届かないまま埋もれる事故が起きうる。
+
+---
+
+### F1. 前提確認フェーズ
+
+最初の問い (Skill 起動直後にこれを聞く):
+
+> AWS Cost Anomaly Detection の Monitor は既に設定されていますか？
+
+#### Monitor が既にある場合 (主想定)
+
+- Monitor の **Region と名前** を確認する
+- 以降の SNS Topic / Lambda / SSM などはすべてこの Region に揃える (Cost Anomaly Detection の SNS 通知は同一 Region の SNS Topic にしか届かないことに注意。最新仕様は AWS docs を確認)
+- 既存 Monitor の閾値・dimension は触らない (既存運用が決めるもの)
+
+#### Monitor が無い場合 (副次対応)
+
+- 「作成サポートを希望しますか？」と確認
+- 希望する場合は `references/monitor-creation.md` に従う
+- 何を監視軸 (dimension) にするかは End User の運用判断。このガイドは値を提示しない
+
+---
+
+### F2. Slack App 準備フェーズ
+
+#### 新規作成 / 既存流用の確認
+
+> Slack App は新規に作成しますか、既存の App を流用しますか？
+
+#### 新規作成の場合
+
+伝えるのは「何が必要か」だけ。詳細 YAML はこのガイドに固定で持たない (時間で陳腐化するため):
+
+- 必須 bot scopes: `app_mentions:read`, `chat:write`, `files:write`
+- Event Subscription (`app_mention`) と Interactivity の有効化
+- Request URL には Lambda Function URL を後で設定する (Function URL は F4 以降に確定するため、ここでは「あとで設定する箇所がある」とだけ伝える)
+- Bot Token と Signing Secret は控えておく (F3 で SSM に投入する)
+
+**完全な manifest テンプレートは固定で書かない**。最新は OSS の `README.md` または Slack API 公式 docs を一次資料として参照させる。Slack manifest は時間でフィールドが増減するため、Skill 内に貼り付けない方針。詳細は `references/slack-app-setup.md` を参照。
+
+#### Slack チャンネル決定 (このガイドで End User に能動的決定を求める唯一の項目)
+
+> Cost Anomaly 通知を流す Slack チャンネル ID を決めてください。
+
+- channel ID (`C` から始まる ID) を控えておく (F3 で SSM に投入する)
+- Bot を当該チャンネルに招待することも忘れない
+
+---
+
+### F3. Reactor 構築フェーズ (IAM / SSM / SQS / DynamoDB)
+
+`_examples/example_aws.tf` が骨格として最も近い。**重複する詳細はそちらに委ね**、このガイドは落とし穴だけ伝える。
+
+詳細は `references/operational-knowledge.md` を参照。要点:
+
+- **SSM Secret は dummy 値 + `lifecycle.ignore_changes = [value]` で投入**し、実値はマネコンで入れる (tfstate に Secret を書かない運用)
+- **IAM**: マルチアカウント運用時は `organizations:DescribeAccount` を追加で許可する (`_examples` の最小 IAM には含まれていない)
+- **命名**: `_examples` のリソース名は参考値。End User のプロジェクト命名規則に従う
+
+このフェーズの apply 後、SSM パラメータが 3 つ (Bot Token, Signing Secret, Slack Channel) 存在することを確認する。dummy のままで OK。
+
+---
+
+### F4. Lambda デプロイフェーズ
+
+- **bootstrap バイナリは GitHub Releases からダウンロードする**運用を基本案内 (ローカルビルド前提にしない)。最新リリースバージョンは GitHub の Releases ページを毎回確認する
+- **lambroll で deploy**。Lambda Function URL も lambroll 側で管理する想定 (Terraform 側は data source で URL を読む構成)
+- **Lambda Timeout は 60 秒推奨**。`_examples/function.json` のデフォルトは 5 秒で、初回起動や DynamoDB テーブル自動作成時に不足する場面がある
+- Lambda 環境変数のキー (`SQS_QUEUE_NAME`, `SSMWRAP_PATHS`, `DYNAMODB_TABLE_NAME` 等) は `_examples/function.json` を参照
+- 初回 deploy 後、**マネコンで SSM の Secret 実値 (dummy → 本物のトークン/シークレット) を入れて Lambda を再デプロイ**する。これを行うと Slack 側の Event Subscription Verification が通る
+
+`_examples/Makefile` の lambroll コマンド例がそのまま使える。
+
+---
+
+### F5. SNS Topic 構築 + 疎通確認フェーズ
+
+**このフェーズが完了するまで F6 (Monitor 接続) には進まない**。
+
+#### SNS Topic を作る
+
+- F1 で確認した Region に作成
+- topic policy に `costalerts.amazonaws.com` の `SNS:Publish` を許可する (条件に `aws:SourceAccount` を付ける)。サンプルは `references/sns-topic-policy.md` を参照
+- 最新の正確な許可仕様は AWS Cost Anomaly Detection の docs を一次資料で確認
+
+#### SNS → Lambda の HTTPS Subscription
+
+- Endpoint は `<Lambda Function URL>amazon-sns` (URL の末尾スラッシュに注意)
+- Subscription の確認 (Confirmation) は Lambda 側のコードが処理するため、Lambda が稼働状態であることが前提
+
+#### 疎通確認 (本フェーズの肝)
+
+- SNS Topic に **ダミーメッセージを publish して Slack に通知が届くこと**を確認する
+- 手順は `references/smoke-test.md` を参照
+- これが通らないうちに F6 へ進まないこと
+
+---
+
+### F6. Monitor 接続フェーズ (最終ステップ)
+
+疎通確認 OK 後にのみ実行する。
+
+- 既存 Cost Anomaly Monitor に **Alert Subscription を追加**し、subscriber を F5 で作った SNS Topic ARN に向ける
+- 閾値 (絶対額 `$` と変動率 `%`) は **既存運用に従う**。このガイドは値を提示しない (環境依存)
+- 最新の Alert Subscription 仕様は AWS docs を確認
+
+この設定が完了すると、本物の Cost Anomaly が検知されたタイミングで Slack に通知が届くようになる。
+
+---
+
+## ガイドが扱わないこと (スコープ外)
+
+- 既存 Cost Anomaly Monitor の閾値・dimension 調整助言 (既存運用に従う前提)
+- Slack 以外の通知先 (MS Teams, Chime 等) への拡張
+- Slack Bot Token の rotation 運用
+- 動作モード (自動 / 手動 / 承認フロー) — End User の Claude Code 環境側の責務
+
+## 最新情報の確認が必要な箇所 (各フェーズで End User に促すこと)
+
+| 何 | どこで確認 |
+|---|---|
+| Slack App manifest の最新フィールド | Slack API 公式 docs / OSS の `README.md` |
+| AWS Cost Anomaly Detection の SNS 通知仕様 | AWS docs (cost-management user guide) |
+| SNS topic policy の `costalerts.amazonaws.com` 許可形式 | AWS docs |
+| このOSS の最新リリースバージョン (bootstrap バイナリ) | GitHub Releases |
+| Terraform AWS provider のリソース仕様 | Terraform Registry |
+
+Skill 本体が固定値で持つには陳腐化が早すぎる情報は、上記の一次資料から都度引くこと。
+
+## reference ファイル一覧
+
+- `references/operational-knowledge.md` — SSM dummy 値運用、IAM 追加権限、Lambda Timeout などの実運用知見
+- `references/sns-topic-policy.md` — `costalerts.amazonaws.com` を許可する topic policy のサンプル
+- `references/slack-app-setup.md` — Slack App 準備の本質的構成 (manifest 詳細は一次資料に委ねる)
+- `references/monitor-creation.md` — Monitor を新規に作る場合のリソース構成
+- `references/smoke-test.md` — SNS への dummy publish による疎通確認手順

--- a/.claude/skills/setup-reactor/references/monitor-creation.md
+++ b/.claude/skills/setup-reactor/references/monitor-creation.md
@@ -1,0 +1,29 @@
+# Cost Anomaly Monitor を新規に作る場合
+
+F1 で「Monitor が既にある」場合はこのドキュメントは不要。**Monitor が無く、作成サポートを希望する場合のみ**読む。
+
+このリポジトリの主目的は「既存 Monitor の通知を Slack に流すこと」であり、Monitor 自体の運用設計はスコープ外。ここでは「Slack 通知を試すために最低限の Monitor を立てる」場合の構成例だけを示す。**何を監視軸にするか (dimension の選択) は End User の運用判断**であり、このガイドは推奨値を提示しない。
+
+最新の Cost Anomaly Detection リソース仕様は AWS docs および Terraform Registry を参照すること:
+- AWS Cost Anomaly Detection: https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html
+- Terraform `aws_ce_anomaly_monitor`: Terraform Registry を確認
+
+## 最小構成 (Terraform 例)
+
+```hcl
+resource "aws_ce_anomaly_monitor" "example" {
+  name              = "<好きな名前>"   # 命名規則は End User のプロジェクトに合わせる
+  monitor_type      = "DIMENSIONAL"   # or "CUSTOM" で LinkedAccount 等を指定
+  monitor_dimension = "SERVICE"        # 何を見るかは運用判断
+}
+```
+
+`monitor_type = "CUSTOM"` を使うと特定の LinkedAccount や Service / Tag に絞った Monitor を作れる。詳細は Terraform Registry の `aws_ce_anomaly_monitor` ドキュメントで `monitor_specification` の最新書式を確認。
+
+## Alert Subscription はこの段階では作らない
+
+このフェーズで Alert Subscription を作ってしまうと、Slack 側の疎通確認 (F5) より前に本物の Anomaly 通知が走り出してしまう。**Alert Subscription を作るのは F6 (Monitor 接続フェーズ) で、F5 の疎通確認に成功した後**。
+
+## Region
+
+Cost Anomaly Detection の API endpoint は `us-east-1` だが、SNS 通知は **同じ Region の SNS Topic** にしか届かないという制約がある (最新仕様は AWS docs を確認すること)。SNS Topic / Lambda / SSM はすべて同じ Region に揃える前提で構築する。

--- a/.claude/skills/setup-reactor/references/operational-knowledge.md
+++ b/.claude/skills/setup-reactor/references/operational-knowledge.md
@@ -1,0 +1,59 @@
+# 実運用知見
+
+`_examples/example_aws.tf` を骨格に使う場合に、ドキュメントから読み取りづらい運用上の落とし穴をまとめる。リソース仕様の細部は時間で変わるため、**Terraform AWS provider のドキュメント (Terraform Registry) と AWS 公式 docs を一次資料として最新を確認する**こと。
+
+## SSM Secret を tfstate に書かない運用
+
+`SLACK_BOT_TOKEN` と `SLACK_SIGNING_SECRET` は機微情報。Terraform の `value` に実値を書くと tfstate に平文で残る。
+
+これを避けるためによく取るパターン:
+
+- Terraform 側では `value = "dummy"` で投入
+- `lifecycle { ignore_changes = [value] }` を付けて、以降の Terraform 実行で上書きされないようにする
+- 実値はマネコン (または `aws ssm put-parameter --overwrite`) で書き換える
+
+Slack Channel ID は機微度が低い (`String` 型で投入) ため、通常はそのまま Terraform で管理して問題ない。
+
+最新の Terraform `aws_ssm_parameter` の `lifecycle` 挙動・属性は Terraform Registry を参照。
+
+## IAM: マルチアカウント運用時の追加権限
+
+`_examples/example_aws.tf` の最小 IAM には含まれていないが、Cost Anomaly が他アカウントに紐づく場合や Organizations 配下のアカウント名を取得して通知に出したい場合、以下が必要になることがある:
+
+- `organizations:DescribeAccount`
+
+これは管理アカウント (もしくはそれに準じる権限を持つアカウント) 側で機能する。マルチアカウント運用でないなら不要。
+
+権限不足のときどう動くかは実装側の fallback に依存するため、必要に応じて Lambda の CloudWatch Logs を確認すること。
+
+## Lambda Timeout は 60 秒を推奨
+
+`_examples/function.json` のデフォルトは 5 秒。以下のケースで不足する:
+
+- DynamoDB テーブルを初回自動作成するとき
+- Slack API への通信や AWS Cost Explorer (`ce:GetCostAndUsage`) のレスポンスが遅いとき
+- コールドスタート + 初回起動が重なったとき
+
+`Timeout: 60` を推奨。lambroll で deploy する場合は `function.json` の `Timeout` を 60 に書き換える。
+
+## DynamoDB テーブルの自動作成
+
+Lambda 側のコードが必要に応じて DynamoDB テーブルを作る挙動になっている。そのため IAM に `dynamodb:CreateTable` `dynamodb:DescribeTable` 等が必要 (`_examples/example_aws.tf` には含まれている)。
+
+ただし「自動作成」に頼ると初回起動が遅くなりタイムアウトを引きやすい。気になるなら Terraform 側で DynamoDB テーブルを明示的に作る選択肢もある (テーブル名は環境変数 `DYNAMODB_TABLE_NAME` と一致させる)。
+
+## lambroll と Terraform の責務分担
+
+- **Terraform**: IAM Role, IAM Policy, SQS (+ DLQ), DynamoDB, SSM パラメータ (dummy 値で), CloudWatch Log Group, Lambda の「箱」(dummy zip で空の Lambda)、Event Source Mapping (SQS → Lambda)
+- **lambroll**: Lambda のコード本体 (bootstrap バイナリ) の deploy、Function URL の管理
+
+Function URL を lambroll 側で管理する場合、Terraform 側は `data "aws_lambda_function_url"` でその URL を読み出して SNS Subscription の endpoint に渡す構成にすると、相互の責務が綺麗に分かれる。
+
+最新の lambroll の挙動・オプションは lambroll の README を参照。
+
+## bootstrap バイナリの入手
+
+ローカルビルドではなく GitHub Releases からダウンロードする運用を基本にする (`_examples/Makefile` 参照)。
+
+- 最新リリースバージョンは GitHub Releases ページで毎回確認する。Skill 内に固定で書かない
+- arm64 か x86_64 かは Lambda の `Architectures` と揃える (`_examples` は arm64)

--- a/.claude/skills/setup-reactor/references/slack-app-setup.md
+++ b/.claude/skills/setup-reactor/references/slack-app-setup.md
@@ -1,0 +1,50 @@
+# Slack App 準備
+
+**完全な manifest YAML はここに固定で書かない**。Slack App manifest は時間でフィールドが増減するため (例: トークン rotation や OAuth 仕様の追加)、Skill 内に貼り付けると古い指示を出す原因になる。
+
+**一次資料を必ず確認すること**:
+- OSS の `README.md` 内の manifest サンプル (このリポジトリのルート `README.md`)
+- Slack API 公式 docs (App manifest reference): https://docs.slack.dev/reference/manifests/
+
+OSS の README 自体が古いケースもありうるので、**最新の Slack 仕様で必須フィールドが増えていないか** Slack API docs 側を必ず突き合わせる。
+
+## 本質的に必要な構成 (時間で変わりにくい部分)
+
+### Bot Scopes
+
+- `app_mentions:read` — `app_mention` イベントを受け取るために必要
+- `chat:write` — Slack チャンネルにメッセージを投稿するために必要
+- `files:write` — 添付ファイルを伴う通知を投稿する場合に必要
+
+### Event Subscription
+
+- 有効化する
+- Bot Event として `app_mention` を購読
+- Request URL は **`<Lambda Function URL>/slack/events`** (Lambda deploy 後に確定するため、最初は仮の値で App を作成し、後で書き換える)
+
+### Interactivity
+
+- 有効化する
+- Request URL は Event Subscription と同じ `<Lambda Function URL>/slack/events`
+
+### Socket Mode
+
+- 無効 (このボットは HTTP ベースで動作する)
+
+## 手順の流れ
+
+1. Slack App を新規作成 (or 既存 App を編集)。manifest を貼る場合は **OSS の README** にあるサンプルを土台にし、Slack API docs で必須フィールドの過不足を確認する
+2. App を workspace にインストールし、**Bot Token** (`xoxb-...`) を控える
+3. **Signing Secret** (Basic Information 画面) を控える
+4. 通知先のチャンネル ID (`C` で始まる文字列) を控える。Bot をそのチャンネルに招待しておく
+5. Bot Token / Signing Secret / Channel ID は SSM の対応パラメータに投入する (F3 で作成済みのもの)
+
+## Verification (Lambda 側との接続確認)
+
+- Slack App の Event Subscription 設定画面で Request URL の Verification (URL 検証) ボタンを押す
+- これが成功するためには、**SSM に実値の Signing Secret が入っており、その状態で Lambda が deploy されている必要がある** (Lambda 起動時に SSM から値を読む構成のため)
+- 初回 deploy 時は dummy のまま Verification を試して失敗 → SSM に実値を入れ → Lambda 再 deploy → Verification 再実行、という順序になる
+
+## 補足: token rotation / PKCE 等の新しい設定
+
+Slack 側で `token_rotation_enabled` や PKCE 関連の設定項目が増えている場合がある。**このガイドは追従しない方針**なので、必要なら Slack API docs 側で要否を判断する。基本的には rotation 無効・PKCE 不要で動く前提だが、Slack のポリシー変更に応じて変わる可能性はある。

--- a/.claude/skills/setup-reactor/references/smoke-test.md
+++ b/.claude/skills/setup-reactor/references/smoke-test.md
@@ -1,0 +1,46 @@
+# 疎通確認: SNS Topic にダミー Publish して Slack に届くか確認
+
+F5 のクライマックス。**この確認が成功するまで F6 (Monitor 接続) には進まない**。
+
+理由: 本番の Cost Anomaly 通知は頻度が低く、初回検知を待っていると設定の誤りに気づくのが遅れる。事前に「SNS → Lambda → Slack」の経路だけ単独で疎通させておくと、後から本物の Anomaly が来たときに「届かない原因が SNS の許可なのか Slack 側なのか Cost Anomaly 側なのか」を切り分けやすい。
+
+## 事前確認
+
+- Lambda が deploy されており、CloudWatch Logs にエラーが出ていない
+- SSM の Slack Bot Token / Signing Secret に **実値** が入っている (dummy のままだと Slack 投稿で失敗する)
+- Slack App の Event Subscription Verification が通っている
+- 通知先 Slack チャンネルに Bot が招待されている
+- SNS Topic から Lambda Function URL への HTTPS Subscription が `Confirmed` 状態になっている (`PendingConfirmation` のままだと届かない)
+
+## ダミー Publish 手順
+
+### AWS CLI で publish する場合
+
+```sh
+aws sns publish \
+  --topic-arn <SNS_TOPIC_ARN> \
+  --region <REGION> \
+  --message '<本文文字列>'
+```
+
+メッセージ本文は Lambda 側の handler がパースできる形式である必要がある。**実際のフォーマットや受け付け可能なフィールドは時間で変わる可能性がある**ため、最新は OSS の `reactor/` 配下の handler 実装または `README.md` を確認すること。難しければまずは「任意の文字列で publish して Lambda が起動するか (CloudWatch Logs にイベントが出るか)」だけでも確認価値がある。
+
+### マネコンから publish する場合
+
+SNS Topic の画面で "Publish message" ボタン → message body を入力 → publish。AWS CLI と同様。
+
+## 期待結果
+
+- CloudWatch Logs に Lambda の起動ログが出る
+- Slack の指定チャンネルに通知メッセージが届く
+
+## 届かないときの切り分け
+
+| 症状 | 確認ポイント |
+|---|---|
+| Lambda が起動しない | SNS Subscription が `Confirmed` か。endpoint URL に末尾の `amazon-sns` が付いているか。SNS Topic Policy が `costalerts.amazonaws.com` (および疎通確認時はユーザー自身) からの Publish を許可しているか |
+| Lambda は起動したが Slack に投げない | CloudWatch Logs を確認。SSM の Token が実値か (dummy のままになっていないか)。Bot がチャンネルに招待されているか。Channel ID が正しいか |
+| Slack 側で 401 / signature error | Signing Secret が SSM の実値に置き換わった後、Lambda が再 deploy されているか |
+| Lambda がタイムアウトする | Timeout を 60 秒に上げているか (`references/operational-knowledge.md` 参照) |
+
+疎通確認が通ったら F6 (Monitor 接続) に進む。

--- a/.claude/skills/setup-reactor/references/sns-topic-policy.md
+++ b/.claude/skills/setup-reactor/references/sns-topic-policy.md
@@ -1,0 +1,47 @@
+# SNS Topic Policy: costalerts.amazonaws.com の許可
+
+AWS Cost Anomaly Detection が SNS Topic に Publish できるよう、Topic Policy で `costalerts.amazonaws.com` を許可する必要がある。
+
+**最新の正確な仕様は AWS 公式 docs を一次資料として確認すること**:
+- AWS Cost Anomaly Detection の SNS 通知設定: https://docs.aws.amazon.com/cost-management/latest/userguide/ad-SNS.html
+
+時間で書式や推奨条件が変わる可能性がある。下記サンプルはあくまで現時点での基本形であり、確定的なものとして扱わない。
+
+## サンプル (基本形)
+
+`aws_sns_topic_policy` を使う場合の JSON サンプル。`<TOPIC_ARN>` と `<ACCOUNT_ID>` は環境に応じて差し替える。
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCostAnomalyDetectionPublish",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "costalerts.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "<TOPIC_ARN>",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceAccount": "<ACCOUNT_ID>"
+        }
+      }
+    }
+  ]
+}
+```
+
+## ポイント
+
+- **`aws:SourceAccount` 条件は付ける**。付けないと他アカウントからの偽装 Publish の余地が残る (confused deputy 対策)
+- Topic の暗号化に KMS を使う場合、KMS Key Policy 側でも `costalerts.amazonaws.com` に `kms:GenerateDataKey` / `kms:Decrypt` を許可する必要がある (こちらも `aws:SourceAccount` 条件を付ける)。詳細は AWS docs 参照
+- Region は F1 で確認した Monitor の Region と揃える。Cross-Region Subscription はできない (最新仕様は AWS docs 確認)
+
+## Terraform で書く場合のヒント
+
+- `data "aws_iam_policy_document"` で組み立てて `aws_sns_topic_policy.policy` に渡すと、JSON 直書きより読みやすい
+- Lambda の HTTPS Subscription は `aws_sns_topic_subscription` リソースで `protocol = "https"`, `endpoint = "<Function URL>amazon-sns"` を指定。Subscription Confirmation の自動応答は Lambda 側のコードが行う
+
+Terraform リソースの最新仕様は Terraform Registry を参照。


### PR DESCRIPTION
## Summary

- Add a Claude Code Skill (`.claude/skills/setup-reactor/`) that walks new adopters from confirming an existing AWS Cost Anomaly Detection Monitor through SNS smoke testing and finally connecting the Monitor to Slack notifications.
- Flow is structured as phases F1–F6; the SNS smoke test (F5) must succeed before the Monitor is wired in (F6) so misconfigurations surface before real anomalies are missed.
- Skill body intentionally avoids embedding stale external specs (Slack App manifest YAML, AWS docs URLs, OSS release versions, Terraform resource schemas). Each phase prompts the End User to consult primary sources.
- SPEC.md is kept locally and excluded from this PR (working spec for the skill, not a deliverable).

## Files

- `.claude/skills/setup-reactor/SKILL.md` — trigger description and F1–F6 conversation skeleton.
- `.claude/skills/setup-reactor/references/operational-knowledge.md` — SSM dummy/`ignore_changes` pattern, `organizations:DescribeAccount`, Lambda 60s timeout, lambroll vs Terraform responsibility split.
- `.claude/skills/setup-reactor/references/sns-topic-policy.md` — sample SNS topic policy that allows `costalerts.amazonaws.com` with `aws:SourceAccount` condition.
- `.claude/skills/setup-reactor/references/slack-app-setup.md` — essential Slack App requirements (scopes, event subscription, interactivity). Full manifest is delegated to README / Slack API docs.
- `.claude/skills/setup-reactor/references/monitor-creation.md` — minimal Terraform example when the End User has no Monitor yet.
- `.claude/skills/setup-reactor/references/smoke-test.md` — dummy SNS publish procedure with a triage table.

## Test plan

- [ ] Skill files render correctly on GitHub (Markdown).
- [ ] `grep -rE 'kayac|centurion|whitebait'` returns no hits inside `.claude/skills/setup-reactor/` (other than the spec file, which is not in this PR).
- [ ] `grep -rE 'display_information:|oauth_config:|event_subscriptions:'` returns no hits (no embedded Slack manifest YAML).
- [ ] In a fresh Claude Code session, the skill triggers on phrases like "set up aws-cost-anomaly-slack-reactor" / `/setup-reactor` and the first prompt asks whether a Cost Anomaly Monitor already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)